### PR TITLE
misc: reduce dependabot noise

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,688 +5,696 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/cmd/configschema"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/cmd/mdatagen"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/examples/demo/client"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/examples/demo/server"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/alibabacloudlogserviceexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/awscloudwatchlogsexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/awsemfexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/awskinesisexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/awsprometheusremotewriteexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/awsxrayexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/azuremonitorexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/carbonexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/clickhouseexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/coralogixexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/datadogexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/dynatraceexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/elasticexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/elasticsearchexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/f5cloudexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/fileexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/googlecloudexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/googlecloudpubsubexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/honeycombexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/humioexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/influxdbexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/jaegerexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/jaegerthrifthttpexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/kafkaexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/loadbalancingexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/logzioexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/lokiexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/newrelicexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/observiqexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/opencensusexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/parquetexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/prometheusexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/prometheusremotewriteexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/sapmexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/sentryexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/signalfxexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/skywalkingexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/splunkhecexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/stackdriverexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/sumologicexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/tanzuobservabilityexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/tencentcloudlogserviceexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/exporter/zipkinexporter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/asapauthextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/awsproxy"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/basicauthextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/bearertokenauthextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/fluentbitextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/healthcheckextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/httpforwarder"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/jaegerremotesampling"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/oauth2clientauthextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/observer"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/observer/dockerobserver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/observer/ecsobserver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/observer/ecstaskobserver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/observer/hostobserver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/observer/k8sobserver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/oidcauthextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/pprofextension"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/extension/sigv4authextension"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/extension/storage"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/awsutil"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/containerinsight"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/cwlogs"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/ecsutil"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/k8s"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/metrics"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/proxy"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/xray"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/xray/testdata/sampleapp"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/aws/xray/testdata/sampleserver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/common"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/containertest"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/coreinternal"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/docker"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/k8sconfig"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/kubelet"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/scrapertest"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/sharedcomponent"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/splunk"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/stanza"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/internal/tools"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/batchperresourceattr"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/batchpersignal"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/experimentalmetricmetadata"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/resourcetotelemetry"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/translator/jaeger"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/translator/opencensus"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/translator/prometheusremotewrite"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/translator/signalfx"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/pkg/translator/zipkin"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/attributesprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/cumulativetodeltaprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/deltatorateprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/filterprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/groupbyattrsprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/groupbytraceprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/k8sattributesprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/metricsgenerationprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/metricstransformprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/probabilisticsamplerprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/redactionprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/resourcedetectionprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/resourceprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/routingprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/spanmetricsprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/spanprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/tailsamplingprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/processor/transformprocessor"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/apachereceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/awscontainerinsightreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/awsecscontainermetricsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/awsfirehosereceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/awsxrayreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/carbonreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/cloudfoundryreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/collectdreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/couchbasereceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/couchdbreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/dockerstatsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/dotnetdiagnosticsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/elasticsearchreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/filelogreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/fluentforwardreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/googlecloudpubsubreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/googlecloudspannerreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/hostmetricsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/influxdbreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/jaegerreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/jmxreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/journaldreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/k8sclusterreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/k8seventsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/kafkametricsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/kafkareceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/kubeletstatsreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/memcachedreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/mongodbatlasreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/mongodbreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/mysqlreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/nginxreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/opencensusreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/podmanreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/postgresqlreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/prometheusexecreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/prometheusreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/rabbitmqreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/receivercreator"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/redisreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/sapmreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/signalfxreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/simpleprometheusreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/simpleprometheusreceiver/examples/federation/prom-counter"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+  - package-ecosystem: "gomod"
+    directory: "/receiver/skywalkingreceiver"
+    schedule:
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/splunkhecreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/statsdreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/syslogreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/tcplogreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/udplogreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/wavefrontreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/windowsperfcountersreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/zipkinreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/receiver/zookeeperreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/testbed"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/testbed/mockdatareceivers/mockawsxrayreceiver"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
   - package-ecosystem: "gomod"
     directory: "/tracegen"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/Makefile
+++ b/Makefile
@@ -135,23 +135,23 @@ gendependabot:
 	@echo "  - package-ecosystem: \"github-actions\"" >> ${DEPENDABOT_PATH}
 	@echo "    directory: \"/\"" >> ${DEPENDABOT_PATH}
 	@echo "    schedule:" >> ${DEPENDABOT_PATH}
-	@echo "      interval: \"weekly\"" >> ${DEPENDABOT_PATH}
+	@echo "      interval: \"monthly\"" >> ${DEPENDABOT_PATH}
 	@echo "Add entry for \"/\" docker"
 	@echo "  - package-ecosystem: \"docker\"" >> ${DEPENDABOT_PATH}
 	@echo "    directory: \"/\"" >> ${DEPENDABOT_PATH}
 	@echo "    schedule:" >> ${DEPENDABOT_PATH}
-	@echo "      interval: \"weekly\"" >> ${DEPENDABOT_PATH}
+	@echo "      interval: \"monthly\"" >> ${DEPENDABOT_PATH}
 	@echo "Add entry for \"/\" gomod"
 	@echo "  - package-ecosystem: \"gomod\"" >> ${DEPENDABOT_PATH}
 	@echo "    directory: \"/\"" >> ${DEPENDABOT_PATH}
 	@echo "    schedule:" >> ${DEPENDABOT_PATH}
-	@echo "      interval: \"weekly\"" >> ${DEPENDABOT_PATH}
+	@echo "      interval: \"monthly\"" >> ${DEPENDABOT_PATH}
 	@set -e; for dir in $(ALL_MODULES); do \
 		echo "Add entry for \"$${dir:1}\""; \
 		echo "  - package-ecosystem: \"gomod\"" >> ${DEPENDABOT_PATH}; \
 		echo "    directory: \"$${dir:1}\"" >> ${DEPENDABOT_PATH}; \
 		echo "    schedule:" >> ${DEPENDABOT_PATH}; \
-		echo "      interval: \"weekly\"" >> ${DEPENDABOT_PATH}; \
+		echo "      interval: \"monthly\"" >> ${DEPENDABOT_PATH}; \
 	done
 
 GOMODULES = $(ALL_MODULES) $(PWD)


### PR DESCRIPTION
**Description:** <Describe what has changed.>
<!--Ex. Fixing a bug - Describe the bug and how this fixes the issue.
Ex. Adding a feature - Explain what this achieves.-->

Because of the weird^H^H^H^H^Hinteresting structure of the contrib repo,
we have an overwhelming amount of dependabot noise for this. Especially
since we're behind upstream.

We could turn this off entirely, I suppose. Or - we can modify the
Makefile and just make this noise monthly rather than weekly.

This commit is the result of modifying the `Makefile` to do monthly
updates instead of weekly, as well as the result of running `make gendependabot`.


**Link to tracking Issue:** <Issue number if applicable>

**Testing:** <Describe what testing was performed and which tests were added.>

**Documentation:** <Describe the documentation added.>
