### PR TITLE
Use clickhouse package to instantiate db connection

### DIFF
--- a/exporter/clickhouseexporter/config.go
+++ b/exporter/clickhouseexporter/config.go
@@ -16,12 +16,10 @@ package clickhouseexporter // import "github.com/open-telemetry/opentelemetry-co
 
 import (
 	"errors"
-	"fmt"
 	"net/url"
 	"strings"
 
 	"go.opentelemetry.io/collector/exporter/exporterhelper"
-	"go.uber.org/multierr"
 )
 
 // Config defines configuration for Elastic exporter.
@@ -44,6 +42,10 @@ type Config struct {
 	MetricsTableName string `mapstructure:"metrics_table_name"`
 	// TTLDays is The data time-to-live in days, 0 means no ttl.
 	TTLDays uint `mapstructure:"ttl_days"`
+
+	Addr string `mapstructure:"addr"`
+	Database string `mapstructure:"database"`
+	Username string `mapstructure:"username"`
 }
 
 // QueueSettings is a subset of exporterhelper.QueueSettings.
@@ -58,13 +60,6 @@ var (
 
 // Validate validates the clickhouse server configuration.
 func (cfg *Config) Validate() (err error) {
-	if cfg.DSN == "" {
-		err = multierr.Append(err, errConfigNoDSN)
-	}
-	_, e := parseDSNDatabase(cfg.DSN)
-	if e != nil {
-		err = multierr.Append(err, fmt.Errorf("invalid dsn format:%w", err))
-	}
 	return err
 }
 

--- a/exporter/clickhouseexporter/exporter_logs.go
+++ b/exporter/clickhouseexporter/exporter_logs.go
@@ -18,9 +18,11 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"os"
 	"strings"
 	"time"
 
+	"github.com/ClickHouse/clickhouse-go/v2"
 	_ "github.com/ClickHouse/clickhouse-go/v2" // For register database driver.
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/plog"
@@ -44,12 +46,8 @@ func newLogsExporter(logger *zap.Logger, cfg *Config) (*logsExporter, error) {
 		return nil, err
 	}
 
-	client, err := newClickhouseClient(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	if err = createLogsTable(cfg, client); err != nil {
+	client := newClickhouseClient(cfg)
+	if err := createLogsTable(cfg, client); err != nil {
 		return nil, err
 	}
 
@@ -182,29 +180,44 @@ SETTINGS index_granularity=8192, ttl_only_drop_parts = 1;
 var driverName = "clickhouse" // for testing
 
 // newClickhouseClient create a clickhouse client.
-func newClickhouseClient(cfg *Config) (*sql.DB, error) {
-	return sql.Open(driverName, cfg.DSN)
+func newClickhouseClient(cfg *Config) (*sql.DB) {
+	return clickhouse.OpenDB(&clickhouse.Options{
+		Addr: []string{cfg.Addr},
+		Auth: clickhouse.Auth{
+			Database: cfg.Database,
+			Username: cfg.Username,
+			Password: os.Getenv("CLICKHOUSE_PASSWORD"),
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+		DialTimeout: time.Second * 30,
+		Debug: false,
+		BlockBufferSize: 10,
+	})
 }
 
 func createDatabase(cfg *Config) error {
-	database, _ := parseDSNDatabase(cfg.DSN)
-	if database == defaultDatabase {
-		return nil
-	}
-	// use default database to create new database
-	dsnUseDefaultDatabase, err := getDefaultDSN(cfg.DSN, database)
-	if err != nil {
-		return err
-	}
-	db, err := sql.Open(driverName, dsnUseDefaultDatabase)
-	if err != nil {
-		return fmt.Errorf("sql.Open:%w", err)
-	}
+	db := clickhouse.OpenDB(&clickhouse.Options{
+		Addr: []string{cfg.Addr},
+		Auth: clickhouse.Auth{
+			Database: cfg.Database,
+			Username: cfg.Username,
+			Password: os.Getenv("CLICKHOUSE_PASSWORD"),
+		},
+		Settings: clickhouse.Settings{
+			"max_execution_time": 60,
+		},
+		DialTimeout: time.Second * 30,
+		Debug: false,
+		BlockBufferSize: 10,
+	})
+
 	defer func() {
 		_ = db.Close()
 	}()
-	query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", database)
-	_, err = db.Exec(query)
+	query := fmt.Sprintf("CREATE DATABASE IF NOT EXISTS %s", cfg.Database)
+	_, err := db.Exec(query)
 	if err != nil {
 		return fmt.Errorf("create database:%w", err)
 	}

--- a/exporter/clickhouseexporter/exporter_metrics.go
+++ b/exporter/clickhouseexporter/exporter_metrics.go
@@ -40,13 +40,10 @@ func newMetricsExporter(logger *zap.Logger, cfg *Config) (*metricsExporter, erro
 	if err := createDatabase(cfg); err != nil {
 		return nil, err
 	}
-	client, err := newClickhouseClient(cfg)
-	if err != nil {
-		return nil, err
-	}
+	client := newClickhouseClient(cfg)
 
 	internal.SetLogger(logger)
-	if err = internal.NewMetricsTable(cfg.MetricsTableName, cfg.TTLDays, client); err != nil {
+	if err := internal.NewMetricsTable(cfg.MetricsTableName, cfg.TTLDays, client); err != nil {
 		return nil, err
 	}
 

--- a/exporter/clickhouseexporter/exporter_traces.go
+++ b/exporter/clickhouseexporter/exporter_traces.go
@@ -43,12 +43,9 @@ func newTracesExporter(logger *zap.Logger, cfg *Config) (*tracesExporter, error)
 		return nil, err
 	}
 
-	client, err := newClickhouseClient(cfg)
-	if err != nil {
-		return nil, err
-	}
+	client := newClickhouseClient(cfg)
 
-	if err = createTracesTable(cfg, client); err != nil {
+	if err := createTracesTable(cfg, client); err != nil {
 		return nil, err
 	}
 
@@ -308,7 +305,6 @@ func renderCreateTraceIDTsTableSQL(cfg *Config) string {
 }
 
 func renderTraceIDTsMaterializedViewSQL(cfg *Config) string {
-	database, _ := parseDSNDatabase(cfg.DSN)
 	return fmt.Sprintf(createTraceIDTsMaterializedViewSQL, cfg.TracesTableName,
-		database, cfg.TracesTableName, database, cfg.TracesTableName)
+		cfg.Database, cfg.TracesTableName, cfg.Database, cfg.TracesTableName)
 }


### PR DESCRIPTION
Authentication to Clickhouse was not working in the clickhouse exporter (for me, at least). The fix was to replace [db.Open](https://pkg.go.dev/database/sql#Open) with [`clickhouse.OpenDB`](https://pkg.go.dev/github.com/beebeeep/clickhouse-go/v2#OpenDB), which is what the clickhouse-go readme uses.
